### PR TITLE
fix(urls): Corrige o NameError na URL de votação

### DIFF
--- a/cursos/urls.py
+++ b/cursos/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from django.contrib.auth import views as auth_views
-from .views import CustomLoginView, register, register_done, detalhe_curso, ver_aula, editar_perfil, logout_view, adicionar_resposta
+from .views import CustomLoginView, register, register_done, detalhe_curso, ver_aula, editar_perfil, logout_view, adicionar_resposta, votar_resposta
 
 app_name = 'cursos'
 


### PR DESCRIPTION
Este PR corrige um bug crítico (NameError) que impedia o funcionamento do sistema de votos.

Causa do Problema:
A view votar_resposta estava sendo usada na URLconf sem ter sido importada previamente, resultando no erro.