### PR TITLE
fix(settings): Direciona utilizadores não autenticados para a página de login correta

### DIFF
--- a/core/settings.py
+++ b/core/settings.py
@@ -128,3 +128,4 @@ MEDIA_ROOT = BASE_DIR / 'media'
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 LOGIN_REDIRECT_URL = 'home'
+LOGIN_URL = 'cursos:login'


### PR DESCRIPTION
Este PR corrige um bug crítico onde utilizadores anónimos eram redirecionados para uma página de login inexistente (/accounts/login/) ao tentar aceder a conteúdo protegido.

Causa do Problema
A definição LOGIN_URL não estava configurada no settings.py, fazendo com que o Django usasse o seu valor padrão.