### PR TITLE
fix(q&a): Corrige o bug de desaparecimento e ordenação de respostas

### DIFF
--- a/cursos/models.py
+++ b/cursos/models.py
@@ -1,6 +1,8 @@
 from django.db import models
 from django.contrib.auth.models import User
 from django.utils.text import slugify
+from django.db.models import Count
+from django.db.models.functions import Coalesce
 
 
 class Associado(models.Model):
@@ -66,6 +68,11 @@ class Pergunta(models.Model):
     usuario = models.ForeignKey(User, on_delete=models.CASCADE, verbose_name="Usuário")
     conteudo = models.TextField(verbose_name="Conteúdo da Pergunta")
     data_criacao = models.DateTimeField(auto_now_add=True)
+
+    def get_respostas_ordenadas(self):
+        return self.respostas.annotate(
+            num_votos=Coalesce(Count('votos'), 0)
+        ).order_by('-num_votos', 'data_criacao')
 
     class Meta:
         ordering = ['data_criacao']

--- a/cursos/templates/cursos/ver_aula.html
+++ b/cursos/templates/cursos/ver_aula.html
@@ -91,7 +91,7 @@
 
         <div class="qa-section">
             <h2>Perguntas e Discussões</h2>
-            <!-- Formulário de Pergunta ATUALIZADO para a lógica unificada -->
+            <!-- Não precisa de mudar o formulário de pergunta -->
             <form method="post" class="question-form" action="{% url 'cursos:ver_aula' pk=aula.pk %}">
                 {% csrf_token %}
                 {{ form_pergunta.as_p }}
@@ -108,7 +108,8 @@
                         <p class="question-content">{{ pergunta.conteudo|linebreaks }}</p>
 
                         <div class="replies-container">
-                            {% for resposta in pergunta.respostas.all|dictsortreversed:"total_votos" %}
+                            <!-- A CORREÇÃO ESTÁ AQUI: Usamos o nosso novo método -->
+                            {% for resposta in pergunta.get_respostas_ordenadas %}
                                 <div class="reply">
                                     <p>
                                         <span class="reply-author">{{ resposta.usuario.first_name }} {{ resposta.usuario.last_name }}</span>
@@ -126,7 +127,7 @@
                                 </div>
                             {% endfor %}
 
-                            <!-- Formulário de Resposta ATUALIZADO para a lógica unificada -->
+                            <!-- Não precisa de mudar o formulário de resposta -->
                             <form method="post" action="{% url 'cursos:ver_aula' pk=aula.pk %}" class="reply-form">
                                 {% csrf_token %}
                                 <input type="hidden" name="pergunta_id" value="{{ pergunta.pk }}">
@@ -141,6 +142,5 @@
             </div>
         </div>
     </main>
-
 </body>
 </html>

--- a/cursos/views.py
+++ b/cursos/views.py
@@ -71,6 +71,9 @@ def detalhe_curso(request, pk):
 def ver_aula(request, pk):
     aula = get_object_or_404(Aula, pk=pk)
 
+    form_pergunta = PerguntaForm()
+    form_resposta = RespostaForm()
+
     if request.method == 'POST':
         if 'submit_pergunta' in request.POST:
             form_pergunta = PerguntaForm(request.POST)
@@ -80,7 +83,8 @@ def ver_aula(request, pk):
                 nova_pergunta.usuario = request.user
                 nova_pergunta.save()
                 return redirect('cursos:ver_aula', pk=aula.pk)
-        elif 'submit_reposta' in request.POST:
+
+        elif 'submit_resposta' in request.POST:
             form_resposta = RespostaForm(request.POST)
             pergunta_id = request.POST.get('pergunta_id')
             if form_resposta.is_valid() and pergunta_id:
@@ -91,18 +95,14 @@ def ver_aula(request, pk):
                 nova_resposta.save()
                 return redirect('cursos:ver_aula', pk=aula.pk)
 
-    form_pergunta = PerguntaForm()
-    form_resposta = RespostaForm()
-    perguntas_da_aula = Pergunta.objects.filter(aula=aula).prefetch_related('respostas__usuario', 'respostas__votos')
-
-    embed_url = f"https://www.youtube.com/embed/{aula.youtube_video_id}"
+    perguntas_da_aula = Pergunta.objects.filter(aula=aula)
 
     context = {
         'aula': aula,
-        'embed_url': embed_url,
         'perguntas': perguntas_da_aula,
         'form_pergunta': form_pergunta,
         'form_resposta': form_resposta,
+        'embed_url': f'https://www.youtube.com/embed/{aula.youtube_video_id}',
     }
 
     return render(request, 'cursos/ver_aula.html', context=context)


### PR DESCRIPTION
Este PR corrige dois bugs críticos na secção de Q&A:
Um bug onde as respostas existentes desapareciam após a submissão de uma nova resposta.
Um bug onde a ordenação por votos não funcionava corretamente.

Causa do Problema
A lógica de submissão na view era frágil e o filtro de ordenação no template falhava silenciosamente.