### PR TITLE
feat(dashboard): Implementa o Painel do Instrutor com gestão de associados

### DIFF
--- a/cursos/context_processors.py
+++ b/cursos/context_processors.py
@@ -1,7 +1,14 @@
-from .models import Notificacao
+from .models import Notificacao, Organizacao
+
 
 def unread_notifications(request):
+    contexto = {}
     if request.user.is_authenticated:
-        count = Notificacao.objects.filter(destinatario=request.user, lida=False).count()
-        return {'unread_notification_count': count}
+        contexto['unread_notification_count'] = Notificacao.objects.filter(destinatario=request.user,
+                                                                           lida=False).count()
+
+        contexto['is_org_owner'] = Organizacao.objects.filter(dono=request.user).exists()
+
+        return contexto
     return {}
+

--- a/cursos/templates/cursos/detalhe_curso.html
+++ b/cursos/templates/cursos/detalhe_curso.html
@@ -44,9 +44,8 @@
 <body>
 
     <header class="header">
-        <div class="logo">
-            <a href="{% url 'home' %}">Plataforma</a>
-        </div>
+        <!-- AQUI ESTÁ A CORREÇÃO -->
+        <h1><a href="{% url 'home' %}">Plataforma de Cursos</a></h1>
         <div class="user-info">
             {% if user.is_authenticated %}
                 <a href="{% url 'cursos:notificacoes' %}" class="notification-bell">
@@ -56,7 +55,13 @@
                     {% endif %}
                 </a>
                 <span>Olá, {{ user.first_name }}!</span>
-                <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+
+                {% if is_org_owner %}
+                    <a href="{% url 'cursos:painel_instrutor' %}">Painel do Instrutor</a>
+                {% else %}
+                    <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+                {% endif %}
+
                 <a href="{% url 'cursos:logout' %}" class="logout">Sair</a>
             {% endif %}
         </div>

--- a/cursos/templates/cursos/lista_cursos.html
+++ b/cursos/templates/cursos/lista_cursos.html
@@ -46,7 +46,8 @@
 <body>
 
     <header class="header">
-        <h1>Plataforma de Cursos</h1>
+        <!-- AQUI ESTÁ A CORREÇÃO -->
+        <h1><a href="{% url 'home' %}">Plataforma de Cursos</a></h1>
         <div class="user-info">
             {% if user.is_authenticated %}
                 <a href="{% url 'cursos:notificacoes' %}" class="notification-bell">
@@ -56,7 +57,13 @@
                     {% endif %}
                 </a>
                 <span>Olá, {{ user.first_name }}!</span>
-                <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+
+                {% if is_org_owner %}
+                    <a href="{% url 'cursos:painel_instrutor' %}">Painel do Instrutor</a>
+                {% else %}
+                    <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+                {% endif %}
+
                 <a href="{% url 'cursos:logout' %}" class="logout">Sair</a>
             {% endif %}
         </div>

--- a/cursos/templates/cursos/meu_painel.html
+++ b/cursos/templates/cursos/meu_painel.html
@@ -58,9 +58,8 @@
 <body>
 
     <header class="header">
-        <div class="logo">
-            <a href="{% url 'home' %}">Plataforma</a>
-        </div>
+        <!-- AQUI ESTÁ A CORREÇÃO -->
+        <h1><a href="{% url 'home' %}">Plataforma de Cursos</a></h1>
         <div class="user-info">
             {% if user.is_authenticated %}
                 <a href="{% url 'cursos:notificacoes' %}" class="notification-bell">
@@ -70,7 +69,13 @@
                     {% endif %}
                 </a>
                 <span>Olá, {{ user.first_name }}!</span>
-                <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+
+                {% if is_org_owner %}
+                    <a href="{% url 'cursos:painel_instrutor' %}">Painel do Instrutor</a>
+                {% else %}
+                    <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+                {% endif %}
+
                 <a href="{% url 'cursos:logout' %}" class="logout">Sair</a>
             {% endif %}
         </div>

--- a/cursos/templates/cursos/notificacoes.html
+++ b/cursos/templates/cursos/notificacoes.html
@@ -22,14 +22,24 @@
 </head>
 <body>
     <header class="header">
-        <div class="logo">
-            <a href="{% url 'home' %}">Plataforma</a>
-        </div>
+        <!-- AQUI ESTÁ A CORREÇÃO -->
+        <h1><a href="{% url 'home' %}">Plataforma de Cursos</a></h1>
         <div class="user-info">
             {% if user.is_authenticated %}
-                <!-- Futuramente, o sininho de notificação virá aqui -->
+                <a href="{% url 'cursos:notificacoes' %}" class="notification-bell">
+                    <span class="bell-icon">🔔</span>
+                    {% if unread_notification_count > 0 %}
+                        <span class="badge">{{ unread_notification_count }}</span>
+                    {% endif %}
+                </a>
                 <span>Olá, {{ user.first_name }}!</span>
-                <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+
+                {% if is_org_owner %}
+                    <a href="{% url 'cursos:painel_instrutor' %}">Painel do Instrutor</a>
+                {% else %}
+                    <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+                {% endif %}
+
                 <a href="{% url 'cursos:logout' %}" class="logout">Sair</a>
             {% endif %}
         </div>

--- a/cursos/templates/cursos/painel_instrutor.html
+++ b/cursos/templates/cursos/painel_instrutor.html
@@ -74,7 +74,7 @@
                             </div>
                             <div>
                                 <!-- Futuramente, este botão irá acionar uma view para aprovar o utilizador -->
-                                <a href="#" class="btn-approve">Aprovar</a>
+                                <a href="{% url 'cursos:aprovar_associado' pk_associado=associado.pk %}" class="btn-approve">Aprovar</a>
                             </div>
                         </li>
                     {% endfor %}

--- a/cursos/templates/cursos/painel_instrutor.html
+++ b/cursos/templates/cursos/painel_instrutor.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Painel do Instrutor - Plataforma de Cursos</title>
+    <style>
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif; margin: 0; background-color: #f8f9fa;}
+        .header { background-color: #fff; padding: 1em 2em; box-shadow: 0 2px 4px rgba(0,0,0,0.1); display: flex; justify-content: space-between; align-items: center; }
+        .header .logo a { text-decoration: none; color: #343a40; font-size: 1.5em; font-weight: bold;}
+        .header .user-info { display: flex; align-items: center; gap: 1.5em; }
+        .header .user-info a { color: #007bff; text-decoration: none; font-weight: bold; }
+        .header .user-info a.logout { color: #dc3545; }
+        .container { max-width: 1200px; margin: 2em auto; padding: 0 2em; }
+
+        /* Estilos do Painel */
+        .dashboard-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 1.5em; margin-bottom: 2em;}
+        .stat-card { background-color: #fff; padding: 1.5em; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.05); text-align: center;}
+        .stat-card .number { font-size: 2.5em; font-weight: bold; color: #007bff; }
+        .stat-card .label { font-size: 1em; color: #6c757d; margin-top: 0.5em; }
+
+        .management-section { background-color: #fff; padding: 2em; border-radius: 8px; box-shadow: 0 4px 8px rgba(0,0,0,0.05); }
+        .management-section h2 { margin-top: 0; }
+        .user-list { list-style: none; padding: 0; }
+        .user-item { display: flex; justify-content: space-between; align-items: center; padding: 1em 0; border-bottom: 1px solid #eee; }
+        .user-item:last-child { border-bottom: none; }
+        .user-details { display: flex; flex-direction: column; }
+        .user-details .name { font-weight: bold; }
+        .user-details .email { font-size: 0.9em; color: #6c757d; }
+        .btn-approve { background-color: #28a745; color: white; padding: 0.5em 1em; text-decoration: none; border-radius: 4px; font-weight: bold; }
+    </style>
+</head>
+<body>
+
+    <header class="header">
+        <div class="logo">
+            <a href="{% url 'home' %}">Plataforma</a>
+        </div>
+        <div class="user-info">
+            {% if user.is_authenticated %}
+                <span>Olá, {{ user.first_name }}!</span>
+                <a href="{% url 'cursos:logout' %}" class="logout">Sair</a>
+            {% endif %}
+        </div>
+    </header>
+
+    <main class="container">
+        <h1>Painel de Controlo da Organização "{{ organizacao.nome }}"</h1>
+
+        <div class="dashboard-grid">
+            <div class="stat-card">
+                <div class="number">{{ total_associados }}</div>
+                <div class="label">Total de Associados</div>
+            </div>
+            <div class="stat-card">
+                <div class="number">{{ total_cursos }}</div>
+                <div class="label">Cursos Publicados</div>
+            </div>
+            <div class="stat-card">
+                <div class="number">{{ associados_pendentes.count }}</div>
+                <div class="label">Cadastros Pendentes</div>
+            </div>
+        </div>
+
+        <div class="management-section">
+            <h2>Aprovar Novos Associados</h2>
+            {% if associados_pendentes %}
+                <ul class="user-list">
+                    {% for associado in associados_pendentes %}
+                        <li class="user-item">
+                            <div class="user-details">
+                                <span class="name">{{ associado.usuario.first_name }} {{ associado.usuario.last_name }}</span>
+                                <span class="email">{{ associado.usuario.email }}</span>
+                            </div>
+                            <div>
+                                <!-- Futuramente, este botão irá acionar uma view para aprovar o utilizador -->
+                                <a href="#" class="btn-approve">Aprovar</a>
+                            </div>
+                        </li>
+                    {% endfor %}
+                </ul>
+            {% else %}
+                <p>Não há nenhum cadastro pendente de aprovação no momento.</p>
+            {% endif %}
+        </div>
+    </main>
+
+</body>
+</html>

--- a/cursos/templates/cursos/painel_instrutor.html
+++ b/cursos/templates/cursos/painel_instrutor.html
@@ -33,12 +33,24 @@
 <body>
 
     <header class="header">
-        <div class="logo">
-            <a href="{% url 'home' %}">Plataforma</a>
-        </div>
+        <!-- AQUI ESTÁ A CORREÇÃO -->
+        <h1><a href="{% url 'home' %}">Plataforma de Cursos</a></h1>
         <div class="user-info">
             {% if user.is_authenticated %}
+                <a href="{% url 'cursos:notificacoes' %}" class="notification-bell">
+                    <span class="bell-icon">🔔</span>
+                    {% if unread_notification_count > 0 %}
+                        <span class="badge">{{ unread_notification_count }}</span>
+                    {% endif %}
+                </a>
                 <span>Olá, {{ user.first_name }}!</span>
+
+                {% if is_org_owner %}
+                    <a href="{% url 'cursos:painel_instrutor' %}">Painel do Instrutor</a>
+                {% else %}
+                    <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+                {% endif %}
+
                 <a href="{% url 'cursos:logout' %}" class="logout">Sair</a>
             {% endif %}
         </div>

--- a/cursos/templates/cursos/ver_aula.html
+++ b/cursos/templates/cursos/ver_aula.html
@@ -61,9 +61,8 @@
 <body>
 
     <header class="header">
-        <div class="logo">
-            <a href="{% url 'cursos:detalhe_curso' pk=aula.curso.pk %}"> &larr; Voltar para {{ aula.curso.titulo }}</a>
-        </div>
+        <!-- AQUI ESTÁ A CORREÇÃO -->
+        <h1><a href="{% url 'home' %}">Plataforma de Cursos</a></h1>
         <div class="user-info">
             {% if user.is_authenticated %}
                 <a href="{% url 'cursos:notificacoes' %}" class="notification-bell">
@@ -73,7 +72,13 @@
                     {% endif %}
                 </a>
                 <span>Olá, {{ user.first_name }}!</span>
-                <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+
+                {% if is_org_owner %}
+                    <a href="{% url 'cursos:painel_instrutor' %}">Painel do Instrutor</a>
+                {% else %}
+                    <a href="{% url 'cursos:meu_painel' %}">Minha Conta</a>
+                {% endif %}
+
                 <a href="{% url 'cursos:logout' %}" class="logout">Sair</a>
             {% endif %}
         </div>

--- a/cursos/urls.py
+++ b/cursos/urls.py
@@ -10,6 +10,7 @@ from .views import (
     votar_resposta,
     marcar_aula_concluida,
     lista_notificacoes,
+    painel_instrutor,
 )
 
 app_name = 'cursos'
@@ -29,6 +30,7 @@ urlpatterns = [
     path('minha-conta/', meu_painel, name='meu_painel'),
 
     path('notificacoes/', lista_notificacoes, name='notificacoes'),
+    path('meu-painel-instrutor/', painel_instrutor, name='painel_instrutor'),
 
     path('password_reset/', auth_views.PasswordResetView.as_view(template_name='cursos/password_reset_form.html', success_url=reverse_lazy('cursos:password_reset_done'), email_template_name='registration/password_reset_email.html'), name='password_reset'),
     path('password_reset/done/', auth_views.PasswordResetDoneView.as_view(template_name='cursos/password_reset_done.html'), name='password_reset_done'),

--- a/cursos/urls.py
+++ b/cursos/urls.py
@@ -11,6 +11,7 @@ from .views import (
     marcar_aula_concluida,
     lista_notificacoes,
     painel_instrutor,
+    aprovar_associado,
 )
 
 app_name = 'cursos'
@@ -31,6 +32,7 @@ urlpatterns = [
 
     path('notificacoes/', lista_notificacoes, name='notificacoes'),
     path('meu-painel-instrutor/', painel_instrutor, name='painel_instrutor'),
+    path('associado/<int:pk_associado>/aprovar/', aprovar_associado, name='aprovar_associado'),
 
     path('password_reset/', auth_views.PasswordResetView.as_view(template_name='cursos/password_reset_form.html', success_url=reverse_lazy('cursos:password_reset_done'), email_template_name='registration/password_reset_email.html'), name='password_reset'),
     path('password_reset/done/', auth_views.PasswordResetDoneView.as_view(template_name='cursos/password_reset_done.html'), name='password_reset_done'),

--- a/cursos/views.py
+++ b/cursos/views.py
@@ -214,7 +214,7 @@ def lista_notificacoes(request):
 @login_required
 def painel_instrutor(request):
     try:
-        organizacao = request.user.organizacao_dono
+        organizacao = Organizacao.objects.get(dono=request.user)
     except Organizacao.DoesNotExist:
         raise Http404
 
@@ -227,20 +227,21 @@ def painel_instrutor(request):
         'organizacao': organizacao,
         'total_associados': total_associados,
         'total_cursos': total_cursos,
-        'associados_pendentes': associados_pendentes
+        'associados_pendentes': associados_pendentes,
     }
 
-    return render(request, 'cursos/painel_administrativo.html', context=context)
+    return render(request, 'cursos/painel_instrutor.html', context=context)
 
 
 @login_required
 def aprovar_associado(request, pk_associado):
     try:
-        organizacao = request.user.organizacao_dono
+        organizacao = Organizacao.objects.get(dono=request.user)
     except Organizacao.DoesNotExist:
-        return HttpResponseForbidden('Você não tem permissão para realizar esta ação.')
+        return HttpResponseForbidden("Você não tem permissão para realizar esta ação.")
 
     associado = get_object_or_404(Associado, pk=pk_associado, organizacao=organizacao)
+
     associado.aprovado = True
     associado.save()
 

--- a/cursos/views.py
+++ b/cursos/views.py
@@ -4,6 +4,7 @@ from .forms import UserRegistrationForm, UserEditForm, PerguntaForm, RespostaFor
 from django.contrib.auth.views import LoginView
 from django.contrib import messages
 from django.contrib.auth import logout
+from django.http import Http404
 from .models import Curso, Aula, Pergunta, Resposta, Associado, Categoria, Notificacao, Organizacao
 
 
@@ -208,3 +209,25 @@ def lista_notificacoes(request):
     }
 
     return render(request, 'cursos/notificacoes.html', context=context)
+
+
+@login_required
+def painel_instrutor(request):
+    try:
+        organizacao = request.user.organizacao_dono
+    except Organizacao.DoesNotExist:
+        raise Http404
+
+    total_associados = Associado.objects.filter(organizacao=organizacao).count()
+    total_cursos = Curso.objects.filter(organizacao=organizacao).count()
+
+    associados_pendentes = Associado.objects.filter(organizacao=organizacao, aprovado=False)
+
+    context = {
+        'organizacao': organizacao,
+        'total_associados': total_associados,
+        'total_cursos': total_cursos,
+        'associados_pendentes': associados_pendentes
+    }
+
+    return render(request, 'cursos/painel_administrativo.html', context=context)

--- a/cursos/views.py
+++ b/cursos/views.py
@@ -4,7 +4,7 @@ from .forms import UserRegistrationForm, UserEditForm, PerguntaForm, RespostaFor
 from django.contrib.auth.views import LoginView
 from django.contrib import messages
 from django.contrib.auth import logout
-from django.http import Http404
+from django.http import Http404, HttpResponseForbidden
 from .models import Curso, Aula, Pergunta, Resposta, Associado, Categoria, Notificacao, Organizacao
 
 
@@ -231,3 +231,17 @@ def painel_instrutor(request):
     }
 
     return render(request, 'cursos/painel_administrativo.html', context=context)
+
+
+@login_required
+def aprovar_associado(request, pk_associado):
+    try:
+        organizacao = request.user.organizacao_dono
+    except Organizacao.DoesNotExist:
+        return HttpResponseForbidden('Você não tem permissão para realizar esta ação.')
+
+    associado = get_object_or_404(Associado, pk=pk_associado, organizacao=organizacao)
+    associado.aprovado = True
+    associado.save()
+
+    return redirect('cursos:painel_instrutor')


### PR DESCRIPTION
Este PR introduz uma funcionalidade de alto valor: um painel de controle exclusivo para o dono da organização (instrutor). Esta interface permite a gestão das atividades mais comuns sem a necessidade de aceder ao painel de administração do Django.

Mudanças Implementadas
Criação da view e do template para o painel_instrutor, que exibe estatísticas chave (total de associados, cursos, cadastros pendentes).

Implementação da funcionalidade de aprovação de associados diretamente a partir do painel, com uma view e URL dedicadas.

Adição de uma verificação de segurança em todas as views relevantes para garantir que apenas o dono da organização possa aceder ao painel e executar ações.

O cabeçalho em todos os templates foi atualizado para exibir um link condicional: "Painel do Instrutor" para o dono da organização e "Minha Conta" para os associados normais.