### PR TITLE
feat(notifications): Implementa notificações para todos os participantes da discussão

### DIFF
--- a/cursos/signals.py
+++ b/cursos/signals.py
@@ -7,11 +7,19 @@ from .models import Resposta, Pergunta, Notificacao
 def criar_notificacao_de_resposta(sender, instance, created, **kwargs):
     if created:
         pergunta = instance.pergunta
-        autor_pergunta = pergunta.usuario
+        autor_da_resposta_atual = instance.usuario
+        participantes = {pergunta.usuario}
 
-        if instance.usuario != autor_pergunta:
+        respostas_anteriores = Resposta.objects.filter(pergunta=pergunta)
+        for resposta in respostas_anteriores:
+            participantes.add(resposta.autor)
+
+        if autor_da_resposta_atual in participantes:
+            participantes.remove(autor_da_resposta_atual)
+
+        for participante in participantes:
             Notificacao.objects.create(
-                destinatario=autor_pergunta,
+                destinatario=participante,
                 resposta=instance
             )
 


### PR DESCRIPTION
Resumo
Este PR melhora significativamente o sistema de notificações, transformando a secção de Q&A numa conversa mais dinâmica.

Mudanças Implementadas
A lógica do sinal criar_notificacao_de_resposta foi refatorada.
Agora, quando uma nova resposta é publicada, o sistema notifica não apenas o autor da pergunta original, mas todos os outros utilizadores que já participaram na discussão, mantendo todos os envolvidos engajados na conversa.