### PR TITLE
fix(notifications): Corrige o AttributeError no sinal de notificação de resposta

### DIFF
--- a/cursos/signals.py
+++ b/cursos/signals.py
@@ -12,7 +12,7 @@ def criar_notificacao_de_resposta(sender, instance, created, **kwargs):
 
         respostas_anteriores = Resposta.objects.filter(pergunta=pergunta)
         for resposta in respostas_anteriores:
-            participantes.add(resposta.autor)
+            participantes.add(resposta.usuario)
 
         if autor_da_resposta_atual in participantes:
             participantes.remove(autor_da_resposta_atual)


### PR DESCRIPTION
Resumo
Este PR corrige um bug crítico que causava um AttributeError ao tentar notificar os participantes de uma discussão quando uma nova resposta era publicada.

Causa do Problema
A função de sinal criar_notificacao_de_resposta estava a tentar aceder ao campo resposta.autor, quando o nome correto do campo no modelo Resposta é usuario.

Mudanças Implementadas
O nome do campo foi corrigido de autor para usuario no ficheiro cursos/signals.py, resolvendo o erro.