### PR TITLE
feat(dashboard): Exibe os resultados dos quizzes no painel do associado

### DIFF
--- a/cursos/templates/cursos/meu_painel.html
+++ b/cursos/templates/cursos/meu_painel.html
@@ -25,6 +25,9 @@
                 <button @click="tab = 'respostas'" :class="{ 'border-primary text-primary': tab === 'respostas', 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300': tab !== 'respostas' }" class="whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
                     Minhas Respostas
                 </button>
+                <button @click="tab = 'resultados'" :class="{ 'border-primary text-primary': tab === 'resultados', 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300': tab !== 'resultados' }" class="whitespace-nowrap py-4 px-1 border-b-2 font-medium text-sm">
+                    Meus Resultados
+                </button
             </nav>
         </div>
 
@@ -111,6 +114,30 @@
                         <li class="py-3 text-gray-500">Você ainda não deu nenhuma resposta.</li>
                     {% endfor %}
                 </ul>
+            </div>
+
+            <!-- Aba 5: Meus Resultados -->
+            <div x-show="tab === 'resultados'" style="display: none;">
+                <h2 class="text-2xl font-semibold mb-4">Meus Resultados das Avaliações</h2>
+                <div class="space-y-4">
+                    {% for resultado in resultado_quizzes %}
+                        <div class="p-4 border rounded-lg flex justify-between items-center">
+                            <div>
+                                <h3 class="font-semibold text-lg">{{ resultado.quiz.curso.titulo }}</h3>
+                                <p class="text-sm text-gray-500">Realizado em: {{ resultado.data_realizacao|date:"d/m/Y" }}</p>
+                            </div>
+                            <div>
+                                {% if resultado.pontuacao >= 70 %}
+                                    <span class="text-2xl font-bold text-green-600">{{ resultado.pontuacao|floatformat:0 }}% (Aprovado)</span>
+                                {% else %}
+                                    <span class="text-2xl font-bold text-red-600">{{ resultado.pontuacao|floatformat:0 }}% (Reprovado)</span>
+                                {% endif %}
+                            </div>
+                        </div>
+                    {% empty %}
+                        <p class="text-center text-gray-500 py-8">Você ainda não concluiu nenhuma avaliação.</p>
+                    {% endfor %}
+                </div>
             </div>
         </div>
     </div>

--- a/cursos/views.py
+++ b/cursos/views.py
@@ -171,12 +171,14 @@ def meu_painel(request):
     minhas_perguntas = Pergunta.objects.filter(usuario=request.user)
     minhas_respostas = Resposta.objects.filter(usuario=request.user)
     meus_cursos_inscritos = associado.cursos_inscritos.all()
+    resultado_quizzes = ResultadoQuiz.objects.filter(associado=associado).order_by('-data_realizacao')
 
     context = {
         'form': form,
         'minhas_perguntas': minhas_perguntas,
         'minhas_respostas': minhas_respostas,
         'meus_cursos': meus_cursos_inscritos,
+        'data_realizacao': resultado_quizzes,
     }
 
     return render(request, 'cursos/meu_painel.html', context=context)

--- a/cursos/views.py
+++ b/cursos/views.py
@@ -178,7 +178,7 @@ def meu_painel(request):
         'minhas_perguntas': minhas_perguntas,
         'minhas_respostas': minhas_respostas,
         'meus_cursos': meus_cursos_inscritos,
-        'data_realizacao': resultado_quizzes,
+        'resultado_quizzes': resultado_quizzes,
     }
 
     return render(request, 'cursos/meu_painel.html', context=context)


### PR DESCRIPTION
Este PR adiciona uma funcionalidade de alto valor ao Painel do Associado: uma nova aba "Meus Resultados" que centraliza o histórico de todas as avaliações que o utilizador já realizou.

Mudanças Implementadas
A view meu_painel foi refatorada para buscar o histórico de ResultadoQuiz do associado logado.
O template meu_painel.html foi atualizado para incluir uma nova aba que mostra os resultados, mostrando o nome do curso, a data de realização, a pontuação e o status de aprovação.

Benefícios
Centraliza o histórico acadêmico do aluno.
Melhora a experiência do utilizador, que não precisa mais de navegar até cada curso para ver as suas notas.